### PR TITLE
Arch build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /cmake-build-debug/
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,4 +38,11 @@ add_executable(traktor_kontrol_s4_mk1_driver_linux
         classes/UtilsHelper.cpp
         main.cpp)
 
-target_link_libraries(traktor_kontrol_s4_mk1_driver_linux rtmidi libevdev.so.2 libasound.so.2 libpthread.so.0)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(PC_EVDEV libevdev REQUIRED)
+find_path(EVDEV_INCLUDE_DIR libevdev/libevdev.h
+          HINTS ${PC_EVDEV_INCLUDE_DIRS} ${PC_EVDEV_INCLUDEDIR})
+find_library(EVDEV_LIBRARY
+        NAMES evdev libevdev)
+include_directories(${EVDEV_INCLUDE_DIR})
+target_link_libraries(traktor_kontrol_s4_mk1_driver_linux rtmidi ${EVDEV_LIBRARY} libasound.so.2 libpthread.so.0)

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ As a command line driver, you can use these parameters:
 ## Build
 1. Install dependencies. The package names will depend on your Linux distribution.
 
-**Ubuntu**
+**Debian/Ubuntu/Raspberry Pi OS**
 ```
 sudo apt install cmake cmake-extras libasound2 librtaudio-dev librtmidi-dev libevdev-dev
 ```
 
 **Arch Linux**
 ```
-pacman -Syu base-devel cmake alsa-lib rtaudio rtmidi libevdev
+sudo pacman -Syu base-devel cmake alsa-lib rtaudio rtmidi libevdev
 ```
 
 2. Build with `cmake`:

--- a/README.md
+++ b/README.md
@@ -12,30 +12,47 @@ Linux driver based on the awesome work from blaxpot and Javi Fonseca on the Trak
 - **snd-usb-caiaq** Kernel Module
 
 ## Usage
- 
+
 As a command line driver, you can use these parameters:
 - **--help** Show help information
 - **--logMode** Set the log mode: console | logfile (default) currently
 - **--logLevel** Set the log verbose level: info | debug currently
 - **--configFile** Set the path where the config file is. Based on JSON format and included in this repo: **config.json**
 
-## Installation
-Installation process is pending, currently you only can download or clone the repo and compile with CMake (>3.16)
-
 ## Build
 1. Install dependencies. The package names will depend on your Linux distribution.
 
+**Ubuntu**
+```
+sudo apt install cmake cmake-extras libasound2 librtaudio-dev librtmidi-dev libevdev-dev
+```
+
 **Arch Linux**
 ```
-pacman -Syu cmake alsa-lib rtaudio rtmidi libevdev
+pacman -Syu base-devel cmake alsa-lib rtaudio rtmidi libevdev
 ```
 
 2. Build with `cmake`:
 ```
-mkdir cmake-build-debug
-cd cmake-build-debug
+mkdir build
+cd build
 cmake ..
 cmake --build .
 ```
+
+If all goes well, you should now be able to start the application like so:
+```
+# ./traktor_kontrol_s4_mk1_driver_linux --logMode console
+[2023-01-20 09:51:40.493] [traktor_kontrol_s4_logger] [info] [main::init_application] Traktor Kontrol S4 Mk1 Driver for Linux started
+[2023-01-20 09:51:40.493] [traktor_kontrol_s4_logger] [info] [main:show_main_configuration] Current arguments:
+[2023-01-20 09:51:40.493] [traktor_kontrol_s4_logger] [info] [main:show_main_configuration] Log level: INFO
+[2023-01-20 09:51:40.493] [traktor_kontrol_s4_logger] [info] [main:show_main_configuration] Log mode: LOG IN CONSOLE
+[2023-01-20 09:51:40.493] [traktor_kontrol_s4_logger] [info] [main::init_application] Starting helpers....
+[2023-01-20 09:51:40.503] [traktor_kontrol_s4_logger] [info] [main::init_application] Get MIDI information....
+[2023-01-20 09:51:40.505] [traktor_kontrol_s4_logger] [info] [main::init_application] Initializing EvDev device....
+```
+
+## Installation
+Installation process is pending, currently you only can download or clone the repo and compile with CMake (>3.16)
 
 ## IN PROCESS

--- a/README.md
+++ b/README.md
@@ -22,4 +22,20 @@ As a command line driver, you can use these parameters:
 ## Installation
 Installation process is pending, currently you only can download or clone the repo and compile with CMake (>3.16)
 
+## Build
+1. Install dependencies. The package names will depend on your Linux distribution.
+
+**Arch Linux**
+```
+pacman -Syu cmake alsa-lib rtaudio rtmidi libevdev
+```
+
+2. Build with `cmake`:
+```
+mkdir cmake-build-debug
+cd cmake-build-debug
+cmake ..
+cmake --build .
+```
+
 ## IN PROCESS

--- a/includes/MidiEventIn.h
+++ b/includes/MidiEventIn.h
@@ -3,6 +3,7 @@
 
 // --------------------------
 #include <map>
+#include <string>
 // --------------------------
 
 using namespace std;


### PR DESCRIPTION
I had a go at building this on Arch Linux and ran some build errors (see below), but was able to get it working by making a small change to `includes/MidiEventIn.h`.

I don't think that change will break anything elsewhere, so figured I'd open this PR about it.

I also added some build instructions to the project README along with a list of dependency package names for Arch.

Build before change:
```
# cmake --build .
[  6%] Building CXX object CMakeFiles/traktor_kontrol_s4_mk1_driver_linux.dir/classes/Button.cpp.o
[ 13%] Building CXX object CMakeFiles/traktor_kontrol_s4_mk1_driver_linux.dir/classes/MidiHelper.cpp.o
[ 20%] Building CXX object CMakeFiles/traktor_kontrol_s4_mk1_driver_linux.dir/classes/EvDevHelper.cpp.o
[ 26%] Building CXX object CMakeFiles/traktor_kontrol_s4_mk1_driver_linux.dir/classes/Knob.cpp.o
[ 33%] Building CXX object CMakeFiles/traktor_kontrol_s4_mk1_driver_linux.dir/classes/Slider.cpp.o
[ 40%] Building CXX object CMakeFiles/traktor_kontrol_s4_mk1_driver_linux.dir/classes/EvDevEvent.cpp.o
[ 46%] Building CXX object CMakeFiles/traktor_kontrol_s4_mk1_driver_linux.dir/classes/Jog.cpp.o
[ 53%] Building CXX object CMakeFiles/traktor_kontrol_s4_mk1_driver_linux.dir/classes/MidiEventIn.cpp.o
In file included from /home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:1:
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:13:21: error: expected ‘)’ before ‘control_channel_1’
   13 |   MidiEventIn(string control_channel_1,
      |              ~      ^~~~~~~~~~~~~~~~~~
      |                     )
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:19:3: error: ‘string’ does not name a type
   19 |   string control_channel_1;
      |   ^~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:20:3: error: ‘string’ does not name a type
   20 |   string control_channel_2;
      |   ^~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:21:3: error: ‘string’ does not name a type
   21 |   string control_channel_3;
      |   ^~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:22:3: error: ‘string’ does not name a type
   22 |   string control_channel_4;
      |   ^~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:23:3: error: ‘string’ does not name a type
   23 |   string control_channel_5;
      |   ^~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:26:3: error: ‘string’ does not name a type
   26 |   string check_channel_value(unsigned char channel);
      |   ^~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:5:25: error: expected constructor, destructor, or type conversion before ‘(’ token
    5 | MidiEventIn::MidiEventIn(string in_control_channel_1,
      |                         ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:18:56: error: new initializer expression list treated as compound expression [-fpermissive]
   18 |       {0x01, new MidiEventIn( "74","118","74","118","-") },
      |                                                        ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:18:56: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [2])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:19:51: error: new initializer expression list treated as compound expression [-fpermissive]
   19 |       {0x02, new MidiEventIn( "-","-","-","-","10") },
      |                                                   ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:19:51: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [3])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [3]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [3]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:20:50: error: new initializer expression list treated as compound expression [-fpermissive]
   20 |       {0x03, new MidiEventIn( "-","-","-","-","6") },
      |                                                  ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:20:50: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [2])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:21:57: error: new initializer expression list treated as compound expression [-fpermissive]
   21 |       {0x05, new MidiEventIn( "83","127","83","127","9" ) },
      |                                                         ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:21:57: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [2])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:22:58: error: new initializer expression list treated as compound expression [-fpermissive]
   22 |       {0x06, new MidiEventIn( "82","126","82","126","13" ) },
      |                                                          ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:22:58: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [3])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [3]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [3]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:23:57: error: new initializer expression list treated as compound expression [-fpermissive]
   23 |       {0x07, new MidiEventIn( "78","122","78","122","8" ) },
      |                                                         ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:23:57: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [2])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:24:58: error: new initializer expression list treated as compound expression [-fpermissive]
   24 |       {0x08, new MidiEventIn( "79","123","79","123","12" ) },
      |                                                          ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:24:58: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [3])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [3]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [3]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:25:58: error: new initializer expression list treated as compound expression [-fpermissive]
   25 |       {0x09, new MidiEventIn( "80","124","80","124","11" ) },
      |                                                          ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:25:58: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [3])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [3]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [3]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:26:57: error: new initializer expression list treated as compound expression [-fpermissive]
   26 |       {0x0A, new MidiEventIn( "81","125","81","125","-" ) },
      |                                                         ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:26:57: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [2])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:27:57: error: new initializer expression list treated as compound expression [-fpermissive]
   27 |       {0x0B, new MidiEventIn( "66","110","66","110","-" ) },
      |                                                         ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:27:57: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [2])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:28:57: error: new initializer expression list treated as compound expression [-fpermissive]
   28 |       {0x0C, new MidiEventIn( "68","112","68","112","-" ) },
      |                                                         ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:28:57: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [2])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:29:57: error: new initializer expression list treated as compound expression [-fpermissive]
   29 |       {0x0D, new MidiEventIn( "70","114","70","114","-" ) },
      |                                                         ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:29:57: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [2])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:30:57: error: new initializer expression list treated as compound expression [-fpermissive]
   30 |       {0x0E, new MidiEventIn( "72","116","72","116","-" ) },
      |                                                         ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:30:57: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [2])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:31:57: error: new initializer expression list treated as compound expression [-fpermissive]
   31 |       {0x0F, new MidiEventIn( "90","134","90","134","-" ) },
      |                                                         ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:31:57: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [2])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:32:57: error: new initializer expression list treated as compound expression [-fpermissive]
   32 |       {0x10, new MidiEventIn( "91","135","91","135","-" ) },
      |                                                         ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:32:57: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [2])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:33:57: error: new initializer expression list treated as compound expression [-fpermissive]
   33 |       {0x11, new MidiEventIn( "92","136","92","136","-" ) },
      |                                                         ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:33:57: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [2])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:34:57: error: new initializer expression list treated as compound expression [-fpermissive]
   34 |       {0x12, new MidiEventIn( "93","137","93","137","-" ) },
      |                                                         ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:34:57: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [2])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:35:51: error: new initializer expression list treated as compound expression [-fpermissive]
   35 |       {0x15, new MidiEventIn( "-","-","-","-","-" ) },
      |                                                   ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:35:51: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [2])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:36:57: error: new initializer expression list treated as compound expression [-fpermissive]
   36 |       {0x17, new MidiEventIn( "76","120","76","120","-" ) },
      |                                                         ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:36:57: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [2])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:37:59: error: new initializer expression list treated as compound expression [-fpermissive]
   37 |       {0x18, new MidiEventIn( "77","121","77","121","154" ) },
      |                                                           ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:37:59: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [4])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [4]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [4]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:38:53: error: new initializer expression list treated as compound expression [-fpermissive]
   38 |       {0x19, new MidiEventIn( "-","-","-","-","155" ) },
      |                                                     ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:38:53: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [4])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [4]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [4]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:39:53: error: new initializer expression list treated as compound expression [-fpermissive]
   39 |       {0x1A, new MidiEventIn( "-","-","-","-","156" ) },
      |                                                     ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:39:53: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [4])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [4]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [4]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:40:53: error: new initializer expression list treated as compound expression [-fpermissive]
   40 |       {0x1B, new MidiEventIn( "-","-","-","-","157" ) },
      |                                                     ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:40:53: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [4])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [4]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [4]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:41:53: error: new initializer expression list treated as compound expression [-fpermissive]
   41 |       {0x1C, new MidiEventIn( "-","-","-","-","158" ) },
      |                                                     ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:41:53: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [4])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [4]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [4]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:42:53: error: new initializer expression list treated as compound expression [-fpermissive]
   42 |       {0x22, new MidiEventIn( "-","-","-","-","159" ) },
      |                                                     ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:42:53: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [4])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [4]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [4]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:43:53: error: new initializer expression list treated as compound expression [-fpermissive]
   43 |       {0x23, new MidiEventIn( "-","-","-","-","160" ) },
      |                                                     ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:43:53: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [4])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [4]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [4]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:44:53: error: new initializer expression list treated as compound expression [-fpermissive]
   44 |       {0x24, new MidiEventIn( "-","-","-","-","161" ) },
      |                                                     ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:44:53: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [4])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [4]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [4]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:45:53: error: new initializer expression list treated as compound expression [-fpermissive]
   45 |       {0x25, new MidiEventIn( "-","-","-","-","162" ) },
      |                                                     ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:45:53: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [4])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [4]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [4]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:46:53: error: new initializer expression list treated as compound expression [-fpermissive]
   46 |       {0x26, new MidiEventIn( "-","-","-","-","163" ) },
      |                                                     ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:46:53: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [4])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [4]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [4]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:47:55: error: new initializer expression list treated as compound expression [-fpermissive]
   47 |       {0x3E, new MidiEventIn( "25","38","51","64","-" ) },
      |                                                       ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:47:55: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [2])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:48:55: error: new initializer expression list treated as compound expression [-fpermissive]
   48 |       {0x3F, new MidiEventIn( "26","39","52","65","-" ) },
      |                                                       ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:48:55: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [2])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:49:55: error: new initializer expression list treated as compound expression [-fpermissive]
   49 |       {0x44, new MidiEventIn( "24","37","50","63","-" ) },
      |                                                       ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:49:55: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [2])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:50:115: error: new initializer expression list treated as compound expression [-fpermissive]
   50 |       {0x46, new MidiEventIn( "16 17 18 19 20 21","29 30 31 32 33 34","42 43 44 45 46 47","55 56 57 58 59 60","-" ) },
      |                                                                                                                   ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:50:115: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [2])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:51:51: error: new initializer expression list treated as compound expression [-fpermissive]
   51 |       {0x50, new MidiEventIn( "-","-","-","-","-" ) },
      |                                                   ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:51:51: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [2])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:52:57: error: new initializer expression list treated as compound expression [-fpermissive]
   52 |       {0x51, new MidiEventIn( "67","111","67","111","-" ) },
      |                                                         ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:52:57: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [2])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:53:57: error: new initializer expression list treated as compound expression [-fpermissive]
   53 |       {0x52, new MidiEventIn( "69","113","69","113","-" ) },
      |                                                         ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:53:57: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [2])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:54:57: error: new initializer expression list treated as compound expression [-fpermissive]
   54 |       {0x53, new MidiEventIn( "71","115","71","115","-" ) },
      |                                                         ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:54:57: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [2])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:55:57: error: new initializer expression list treated as compound expression [-fpermissive]
   55 |       {0x54, new MidiEventIn( "73","117","73","117","-" ) }
      |                                                         ^
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:55:57: error: no matching function for call to ‘MidiEventIn::MidiEventIn(const char [2])’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn()’
   10 | class MidiEventIn
      |       ^~~~~~~~~~~
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   candidate expects 0 arguments, 1 provided
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(const MidiEventIn&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘const MidiEventIn&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note: candidate: ‘constexpr MidiEventIn::MidiEventIn(MidiEventIn&&)’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/./includes/MidiEventIn.h:10:7: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘MidiEventIn&&’
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:58:1: error: could not convert ‘{{1, <expression error>}, {2, <expression error>}, {3, <expression error>}, {5, <expression error>}, {6, <expression error>}, {7, <expression error>}, {8, <expression error>}, {9, <expression error>}, {10, <expression error>}, {11, <expression error>}, {12, <expression error>}, {13, <expression error>}, {14, <expression error>}, {15, <expression error>}, {16, <expression error>}, {17, <expression error>}, {18, <expression error>}, {21, <expression error>}, {23, <expression error>}, {24, <expression error>}, {25, <expression error>}, {26, <expression error>}, {27, <expression error>}, {28, <expression error>}, {34, <expression error>}, {35, <expression error>}, {36, <expression error>}, {37, <expression error>}, {38, <expression error>}, {62, <expression error>}, {63, <expression error>}, {68, <expression error>}, {70, <expression error>}, {80, <expression error>}, {81, <expression error>}, {82, <expression error>}, {83, <expression error>}, {84, <expression error>}}’ from ‘<brace-enclosed initializer list>’ to ‘const std::map<char, MidiEventIn*>’
   58 | };
      | ^
      | |
      | <brace-enclosed initializer list>
/home/blaxpot/code/traktor-kontrol-s4-mk1-driver-linux/classes/MidiEventIn.cpp:60:1: error: ‘string’ does not name a type
   60 | string MidiEventIn::check_channel_value(unsigned char channel){
      | ^~~~~~
make[2]: *** [CMakeFiles/traktor_kontrol_s4_mk1_driver_linux.dir/build.make:230: CMakeFiles/traktor_kontrol_s4_mk1_driver_linux.dir/classes/MidiEventIn.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/traktor_kontrol_s4_mk1_driver_linux.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```

Build after change:
```
# cmake --build .
[  6%] Building CXX object CMakeFiles/traktor_kontrol_s4_mk1_driver_linux.dir/classes/Button.cpp.o
[ 13%] Building CXX object CMakeFiles/traktor_kontrol_s4_mk1_driver_linux.dir/classes/MidiHelper.cpp.o
[ 20%] Building CXX object CMakeFiles/traktor_kontrol_s4_mk1_driver_linux.dir/classes/EvDevHelper.cpp.o
[ 26%] Building CXX object CMakeFiles/traktor_kontrol_s4_mk1_driver_linux.dir/classes/Knob.cpp.o
[ 33%] Building CXX object CMakeFiles/traktor_kontrol_s4_mk1_driver_linux.dir/classes/Slider.cpp.o
[ 40%] Building CXX object CMakeFiles/traktor_kontrol_s4_mk1_driver_linux.dir/classes/EvDevEvent.cpp.o
[ 46%] Building CXX object CMakeFiles/traktor_kontrol_s4_mk1_driver_linux.dir/classes/Jog.cpp.o
[ 53%] Building CXX object CMakeFiles/traktor_kontrol_s4_mk1_driver_linux.dir/classes/MidiEventIn.cpp.o
[ 60%] Building CXX object CMakeFiles/traktor_kontrol_s4_mk1_driver_linux.dir/classes/UtilsHelper.cpp.o
[ 66%] Building CXX object CMakeFiles/traktor_kontrol_s4_mk1_driver_linux.dir/main.cpp.o
[ 73%] Linking CXX executable traktor_kontrol_s4_mk1_driver_linux
[100%] Built target traktor_kontrol_s4_mk1_driver_linux
```